### PR TITLE
Use unittest2 for older Python versions.  Fixes issue #10.

### DIFF
--- a/tests/PyroTests/test_core.py
+++ b/tests/PyroTests/test_core.py
@@ -5,7 +5,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import copy
 import logging
 import os, sys, time

--- a/tests/PyroTests/test_daemon.py
+++ b/tests/PyroTests/test_daemon.py
@@ -6,7 +6,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 
 from __future__ import with_statement
 import os, time, socket
-import unittest
 import Pyro4.core
 import Pyro4.constants
 import Pyro4.socketutil

--- a/tests/PyroTests/test_echoserver.py
+++ b/tests/PyroTests/test_echoserver.py
@@ -4,7 +4,6 @@ Tests for the built-in test echo server.
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
-import unittest
 import time
 import Pyro4.test.echoserver as echoserver
 import Pyro4

--- a/tests/PyroTests/test_flame.py
+++ b/tests/PyroTests/test_flame.py
@@ -5,7 +5,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import Pyro4.utils.flame
 import Pyro4.utils.flameserver
 import Pyro4.errors

--- a/tests/PyroTests/test_ironpython.py
+++ b/tests/PyroTests/test_ironpython.py
@@ -4,7 +4,6 @@ Tests for some Ironpython peculiarities.
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
-import unittest
 import sys
 import pickle
 

--- a/tests/PyroTests/test_naming.py
+++ b/tests/PyroTests/test_naming.py
@@ -5,7 +5,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import time
 import Pyro4.core
 import Pyro4.naming

--- a/tests/PyroTests/test_naming2.py
+++ b/tests/PyroTests/test_naming2.py
@@ -5,7 +5,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import sys, select, os
 import Pyro4.core
 import Pyro4.naming

--- a/tests/PyroTests/test_package.py
+++ b/tests/PyroTests/test_package.py
@@ -4,7 +4,6 @@ Tests for the package structure and import names.
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
-import unittest
 import Pyro4
 import Pyro4.constants
 import Pyro4.core
@@ -14,7 +13,7 @@ import Pyro4.nsc
 import Pyro4.socketutil
 import Pyro4.threadutil
 import Pyro4.util
-
+from testsupport import unittest
 
 class TestPackage(unittest.TestCase):
     def testPyro4(self):

--- a/tests/PyroTests/test_serialize.py
+++ b/tests/PyroTests/test_serialize.py
@@ -5,7 +5,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import sys
 import pprint
 import Pyro4.util

--- a/tests/PyroTests/test_server.py
+++ b/tests/PyroTests/test_server.py
@@ -5,7 +5,6 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import Pyro4.core
 import Pyro4.errors
 import Pyro4.util

--- a/tests/PyroTests/test_server_timeout.py
+++ b/tests/PyroTests/test_server_timeout.py
@@ -4,7 +4,6 @@ Tests for a running Pyro server, with timeouts.
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
-import unittest
 import os
 import test_server
 

--- a/tests/PyroTests/test_socket.py
+++ b/tests/PyroTests/test_socket.py
@@ -4,7 +4,6 @@ Tests for the low level socket functions.
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
-import unittest
 import socket, os, sys
 import Pyro4.socketutil as SU
 from Pyro4 import threadutil

--- a/tests/PyroTests/test_tpjobqueue.py
+++ b/tests/PyroTests/test_tpjobqueue.py
@@ -5,12 +5,11 @@ Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
 from __future__ import with_statement
-import unittest
 import time
 import random
 from Pyro4.tpjobqueue import ThreadPooledJobQueue, JobQueueError
 import Pyro4.threadutil
-
+from testsupport import unittest
 
 MIN_POOL_SIZE = 5
 MAX_POOL_SIZE = 10

--- a/tests/PyroTests/test_util.py
+++ b/tests/PyroTests/test_util.py
@@ -4,8 +4,6 @@ Tests for the utility functions.
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """
 
-import unittest
-
 import sys, imp, os, platform
 import Pyro4.util
 from testsupport import *

--- a/tests/PyroTests/testsupport.py
+++ b/tests/PyroTests/testsupport.py
@@ -11,7 +11,8 @@ import threading
 import pickle
 
 
-__all__=["tobytes", "unicode", "unichr", "StringIO", "next", "AtomicCounter", "NonserializableError", "MyThing2"]
+__all__=["tobytes", "unicode", "unichr", "StringIO", "next", "AtomicCounter",
+        "NonserializableError", "MyThing2", "unittest" ]
 
 if sys.version_info<(3,0):
     from StringIO import StringIO
@@ -32,6 +33,13 @@ if sys.version_info<(2,6):
         return iterable.next()
 else:
     next=next
+
+
+if (sys.version_info >= (2, 7) and sys.version_info < (3, 0)) or \
+        (sys.version_info >= (3, 1)):
+    import unittest
+else:
+    import unittest2 as unittest
 
 
 class AtomicCounter(object):


### PR DESCRIPTION
I have moved version checking to testsupport.py as you advised me.
