### PR TITLE
Fixed tests for python 3.0-3.3 with correct reload() import

### DIFF
--- a/tests/PyroTests/test_core.py
+++ b/tests/PyroTests/test_core.py
@@ -20,7 +20,7 @@ import Pyro4.futures
 from testsupport import *
 
 
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3, 4):
     import importlib
     reload = importlib.reload
 


### PR DESCRIPTION
Tests failed in python 3.0-3.3 as reload() function was
moved to imporlib module since python >= 3.4.

> https://docs.python.org/3/library/importlib.html#importlib.reload
> New in version 3.4.
