### PR TITLE
Fixed tests for python 3.0-3.3 with correct reload() import

### DIFF
--- a/tests/PyroTests/test_core.py
+++ b/tests/PyroTests/test_core.py
@@ -20,7 +20,10 @@ import Pyro4.futures
 from testsupport import *
 
 
-if sys.version_info >= (3, 0):
+if (3, 0) <= sys.version_info < (3, 4):
+    import imp
+    reload = imp.reload
+elif sys.version_info >= (3, 4):
     import importlib
     reload = importlib.reload
 


### PR DESCRIPTION
Tests failed on python 3.0-3.3 as reload() function was
moved from `imp` module to `importlib` since python >= 3.4
