### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - pypy
+install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+  - pip install -e .
+script: 
+  - cd tests 
+  - python -E run_testsuite.py


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/) is free hosted continuous integration for open source projects.

Added initial support that runs tests through `run_testsuite.py`.
It will also be necessary to enable `irmen/Pyro4` repo in Travis settings.
