### PR TITLE
Retrieve metadata in Proxy.__setattr__

### DIFF
--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -241,6 +241,10 @@ class Proxy(object):
     def __setattr__(self, name, value):
         if name in Proxy.__pyroAttributes:
             return super(Proxy, self).__setattr__(name, value)  # one of the special pyro attributes
+        if Pyro4.config.METADATA:
+            # get metadata if it's not there yet
+            if not self._pyroMethods and not self._pyroAttrs:
+                self._pyroGetMetadata()
         if name in self._pyroAttrs:
             return self._pyroInvoke("__setattr__", (name, value), None)  # remote attribute
         if Pyro4.config.METADATA:


### PR DESCRIPTION
This fixes a bug when the first operation on a remote object is setting an attribute. Proxy.\__setattr__ does not attempt to retrieve the metadata, resulting in a "no exposed attribute" error.