### PR TITLE
add auto retry feature

### DIFF
--- a/docs/source/clientcode.rst
+++ b/docs/source/clientcode.rst
@@ -529,7 +529,7 @@ in order to use this automatically retry::
 
     Pyro4.config.MAX_RETRIES = 3      # attempt to retry 3 times before raise the exception
 
-You can also do this on a pre-proxy basis bt setting the max retries property on the proxy::
+You can also do this on a pre-proxy basis by setting the max retries property on the proxy::
 
     proxy._pyroMaxRetries = 3      # attempt to retry 3 times before raise the exception
 

--- a/docs/source/clientcode.rst
+++ b/docs/source/clientcode.rst
@@ -524,6 +524,17 @@ they will execute in
 
 See the :file:`timeout` example for more details.
 
+Also, there is a automatic retry mechanism for timeout or connection closed (by server side),
+in order to use this automatically retry::
+
+    Pyro4.config.MAX_RETRIES = 3      # attempt to retry 3 times before raise the exception
+
+You can also do this on a pre-proxy basis bt setting the max retries property on the proxy::
+
+    proxy._pyroMaxRetries = 3      # attempt to retry 3 times before raise the exception
+
+See the :file:`autoretry` example for more details.
+
 .. index::
     double: reconnecting; automatic
 
@@ -531,7 +542,8 @@ Automatic reconnecting
 ----------------------
 If your client program becomes disconnected to the server (because the server crashed for instance),
 Pyro will raise a :py:exc:`Pyro4.errors.ConnectionClosedError`.
-It is possible to catch this and tell Pyro to attempt to reconnect to the server by calling
+You can use the automatic retry mechanism to handle this exception, see the :file:`autoretry` example for more details.
+Alternatively, it is also possible to catch this and tell Pyro to attempt to reconnect to the server by calling
 ``_pyroReconnect()`` on the proxy (it takes an optional argument: the number of attempts
 to reconnect to the daemon. By default this is almost infinite). Once successful, you can resume operations
 on the proxy::

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -112,6 +112,7 @@ METADATA                bool    True           Client: Get remote object metadat
 REQUIRE_EXPOSE          bool    False          Server: Is @expose required to make members remotely accessible. If False, everything is accessible (this is the default for now).
 USE_MSG_WAITALL         bool    True (False if Some systems have broken socket MSG_WAITALL support. Set this item to False if your system is one of these. Pyro will then use another (but slower) piece of code to receive network data.
                                 on Windows)
+MAX_RETRIES             int     0              Automatically retry network operations for some exceptions (timeout / connection closed), careful to use when remote functions have side effect (e.g.: calling twice results in error)
 ======================= ======= ============== =======
 
 .. index::

--- a/examples/autoretry/Readme.txt
+++ b/examples/autoretry/Readme.txt
@@ -1,0 +1,10 @@
+This is an example that shows the auto retry feature (in the client).
+
+server.py    -- the server you need to run for this example
+client.py    -- client that uses auto retry settings
+
+
+The client disables and enables auto retries to show what happens.
+It shows an exception when auto retries disabled and server side closed the connection, and then use auto retries to avoid the exception raising to user code.
+Suggest to run the server with timeout warning output:
+PYRO_LOGLEVEL=WARNING PYRO_LOGFILE={stderr} python server.py

--- a/examples/autoretry/client.py
+++ b/examples/autoretry/client.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+from time import sleep
+import sys
+
+import Pyro4
+import Pyro4.errors
+
+
+# client side will not have timeout
+Pyro4.config.COMMTIMEOUT = 0
+
+# Not using auto-retry feature
+Pyro4.config.MAX_RETRIES = 0
+
+obj = Pyro4.core.Proxy("PYRONAME:example.autoretry")
+print("Calling remote function 1st time (create connection)")
+obj.add(1, 1)
+print("Calling remote function 2nd time (not timed out yet)")
+obj.add(2, 2)
+print("Sleeping 1 second...")
+sleep(1)
+print("Calling remote function 3rd time (will raise an exception)")
+try:
+    obj.add(3, 3)
+except Exception as e:
+    print("Got exception %r as expected." % repr(e))
+
+print("Now, let's enable the auto retry")
+obj._pyroRelease()
+obj._pyroMaxRetries = 2
+
+print("Calling remote function 1st time (create connection)")
+obj.add(1, 1)
+print("Calling remote function 2nd time (not timed out yet)")
+obj.add(2, 2)
+print("Sleeping 1 second...")
+sleep(1)
+print("Calling remote function 3rd time (will not raise any exceptions)")
+obj.add(3, 3)

--- a/examples/autoretry/server.py
+++ b/examples/autoretry/server.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+import time
+
+import Pyro4
+
+
+class CalcServer(object):
+    def add(self, num1, num2):
+        print("calling add: %d, %d" % (num1, num2))
+        return num1 + num2
+
+
+Pyro4.config.COMMTIMEOUT = 0.5  # the server will very likely timed-out
+
+ns = Pyro4.naming.locateNS()
+daemon = Pyro4.core.Daemon()
+obj = CalcServer()
+uri = daemon.register(obj)
+ns.register("example.autoretry", uri)
+print("Server ready.")
+daemon.requestLoop()

--- a/src/Pyro4/configuration.py
+++ b/src/Pyro4/configuration.py
@@ -23,7 +23,8 @@ class Configuration(object):
                  "THREADPOOL_SIZE", "AUTOPROXY", "PICKLE_PROTOCOL_VERSION",
                  "BROADCAST_ADDRS", "NATHOST", "NATPORT", "MAX_MESSAGE_SIZE",
                  "FLAME_ENABLED", "SERIALIZER", "SERIALIZERS_ACCEPTED", "LOGWIRE",
-                 "METADATA", "REQUIRE_EXPOSE", "USE_MSG_WAITALL", "JSON_MODULE")
+                 "METADATA", "REQUIRE_EXPOSE", "USE_MSG_WAITALL", "JSON_MODULE",
+                 "MAX_RETRIES")
 
     def __init__(self):
         self.reset()
@@ -63,6 +64,7 @@ class Configuration(object):
         self.REQUIRE_EXPOSE = False  # require @expose to make members remotely accessible (if False, everything is accessible)
         self.USE_MSG_WAITALL = hasattr(socket, "MSG_WAITALL") and platform.system() != "Windows"      # not reliable on windows even though it is defined
         self.JSON_MODULE = "json"
+        self.MAX_RETRIES = 0
 
         if useenvironment:
             # process environment variables

--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -171,9 +171,9 @@ class _RemoteMethod(object):
                 return self.__send(self.__name, args, kwargs)
             except (errors.ConnectionClosedError, errors.TimeoutError):
                 # only retry for recoverable network errors
-                pass
-        else:
-            raise  # raise the last exception
+                if attempt >= self.__max_retries:
+                    # last attempt, raise the exception
+                    raise
 
 
 class Proxy(object):

--- a/src/Pyro4/utils/flame.py
+++ b/src/Pyro4/utils/flame.py
@@ -72,7 +72,7 @@ class FlameModule(object):
     def __getattr__(self, item):
         if item in ("__getnewargs__", "__getnewargs_ex__", "__getinitargs__"):
             raise AttributeError(item)
-        return Pyro4.core._RemoteMethod(self.__invoke, "%s.%s" % (self.module, item))
+        return Pyro4.core._RemoteMethod(self.__invoke, "%s.%s" % (self.module, item), 0)
 
     def __getstate__(self):
         return self.__dict__

--- a/tests/PyroTests/test_core.py
+++ b/tests/PyroTests/test_core.py
@@ -572,7 +572,7 @@ class RemoteMethodTests(unittest.TestCase):
                     return "INVOKED name=%s args=%s kwargs=%s" % (name, args, kwargs)
 
                 def __getattr__(self, name):
-                    return Pyro4.core._RemoteMethod(self.invoke, name)
+                    return Pyro4.core._RemoteMethod(self.invoke, name, max_retries=0)
 
             o = ProxyMock()
             self.assertEqual("INVOKED name=foo args=(1,) kwargs={}", o.foo(1))  # normal

--- a/tests/PyroTests/test_serialize.py
+++ b/tests/PyroTests/test_serialize.py
@@ -119,6 +119,7 @@ class SerializeTests_pickle(unittest.TestCase):
 
         proxy = Pyro4.core.Proxy("PYRO:9999@host.com:4444")
         proxy._pyroTimeout = 42
+        proxy._pyroMaxRetries = 78
         self.assertIsNone(proxy._pyroConnection)
         p, _ = self.ser.serializeData(proxy)
         proxy2 = self.ser.deserializeData(p)
@@ -126,6 +127,7 @@ class SerializeTests_pickle(unittest.TestCase):
         self.assertIsNone(proxy2._pyroConnection)
         self.assertEqual(proxy2._pyroUri, proxy._pyroUri)
         self.assertEqual(42, proxy2._pyroTimeout)
+        self.assertEqual(78, proxy2._pyroMaxRetries)
 
     def testNested(self):
         if self.SERIALIZER == "marshal":
@@ -179,6 +181,7 @@ class SerializeTests_pickle(unittest.TestCase):
         proxy._pyroTimeout = 42
         proxy._pyroHmacKey = b"secret"
         proxy._pyroHandshake = "apples"
+        proxy._pyroMaxRetries = 78
         s, c = self.ser.serializeData(proxy)
         x = self.ser.deserializeData(s, c)
         self.assertIsInstance(x, Pyro4.core.Proxy)
@@ -189,6 +192,7 @@ class SerializeTests_pickle(unittest.TestCase):
         self.assertEqual(set("ghi"), x._pyroOneway)
         self.assertEqual(b"secret", x._pyroHmacKey)
         self.assertEqual("apples", x._pyroHandshake)
+        self.assertEqual(78, x._pyroMaxRetries)
         daemon = Pyro4.core.Daemon()
         s, c = self.ser.serializeData(daemon)
         x = self.ser.deserializeData(s, c)
@@ -213,12 +217,13 @@ class SerializeTests_pickle(unittest.TestCase):
         proxy._pyroTimeout = 42
         proxy._pyroHmacKey = b"secret"
         proxy._pyroHandshake = "apples"
+        proxy._pyroMaxRetries = 78
         state = proxy.__getstate_for_dict__()
         if sys.platform == 'cli':
             b64_secret = "b64:"+base64.b64encode("secret").decode("utf-8")
         else:
             b64_secret = "b64:"+base64.b64encode(b"secret").decode("utf-8")
-        self.assertEqual(('PYRO:object@host:4444', tuple(set("ghi")), tuple(set("def")), tuple(set("abc")), 42, b64_secret, "apples"), state)
+        self.assertEqual(('PYRO:object@host:4444', tuple(set("ghi")), tuple(set("def")), tuple(set("abc")), 42, b64_secret, "apples", 78), state)
         proxy2 = Pyro4.core.Proxy("PYRONAME:xxx")
         proxy2.__setstate_from_dict__(state)
         self.assertEqual(proxy, proxy2)
@@ -229,6 +234,7 @@ class SerializeTests_pickle(unittest.TestCase):
         self.assertEqual(proxy._pyroTimeout, proxy2._pyroTimeout)
         self.assertEqual(proxy._pyroHmacKey, proxy2._pyroHmacKey)
         self.assertEqual(proxy._pyroHandshake, proxy2._pyroHandshake)
+        self.assertEqual(proxy._pyroMaxRetries, proxy2._pyroMaxRetries)
         daemon = Pyro4.core.Daemon()
         state = daemon.__getstate_for_dict__()
         self.assertEqual(tuple(), state)


### PR DESCRIPTION
Add a build-in auto retry mechanism for recoverable network exceptions (timeout / connection closed by remote server), make it a better transparent proxy, the user (client side) doesn't have to handle some very common network exceptions.