### PR TITLE
fixed bug so that Name Server can run on a unix socket

### DIFF
--- a/src/Pyro4/naming.py
+++ b/src/Pyro4/naming.py
@@ -483,11 +483,12 @@ def locateNS(host=None, port=None, broadcast=True, hmac_key=None):
     # pyro direct lookup
     if not port:
         port = Pyro4.config.NS_PORT
-    if ":" in host:
-        host = "[%s]" % host
     if core.URI.isUnixsockLocation(host):
         uristring = "PYRO:%s@%s" % (Pyro4.constants.NAMESERVER_NAME, host)
     else:
+        # if not a unix socket, check for ipv6
+	if ":" in host:
+            host = "[%s]" % host
         uristring = "PYRO:%s@%s:%d" % (Pyro4.constants.NAMESERVER_NAME, host, port)
     uri = core.URI(uristring)
     log.debug("locating the NS: %s", uri)

--- a/src/Pyro4/naming.py
+++ b/src/Pyro4/naming.py
@@ -487,7 +487,7 @@ def locateNS(host=None, port=None, broadcast=True, hmac_key=None):
         uristring = "PYRO:%s@%s" % (Pyro4.constants.NAMESERVER_NAME, host)
     else:
         # if not a unix socket, check for ipv6
-	if ":" in host:
+        if ":" in host:
             host = "[%s]" % host
         uristring = "PYRO:%s@%s:%d" % (Pyro4.constants.NAMESERVER_NAME, host, port)
     uri = core.URI(uristring)


### PR DESCRIPTION
If the Name Server is run on a unix socket, for example, with `pyro4-ns --unixsocket=/path/to/socket.sock`, the Pyro server doesn't appear to be able to connect to it.

    Pyro4.locateNS(host='./u:/path/to/socket.sock)

results in

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/apps/Python/lib/python2.7/site-packages/Pyro4/naming.py", line 423, in locateNS
    uri = core.URI(uristring)
      File "/apps/Python/lib/python2.7/site-packages/Pyro4/core.py", line 68, in __init__
    self._parseLocation(location, None)
      File "/apps/Python/lib/python2.7/site-packages/Pyro4/core.py", line 83, in _parseLocation
    self.host, _, self.port = re.match(r"\[([0-9a-fA-F:%]+)](:(\d+))?", location).groups()
    AttributeError: 'NoneType' object has no attribute 'groups'


I believe this is because in line 486 and 487 of `naming.py`, the code is applying ipv6 logic to unix sockets on accident. 

    if ":" in host:
        host = "[%s]" % host

In that snippet, all unix sockets (which start with './u:'), contain a colon, so this if statement will surround it in straight brackets mistakenly.

Core.py's URI.isUnixSockLocation then returns False, because the string is now wrapped in straight brackets:
    
    def isUnixsockLocation(location):
        """determine if a location string is for a Unix domain socket"""
        return location.startswith("./u:")

The traceback above then will occur in `_parseLocation`, starting at the if statement in line 78 (note how the if statement on line 73 cannot execute as the location arg now starts with a `[`, not a `./u:`)

If I move that if statement in `naming.py` inside of the else statement at line 488, it then works:

     if core.URI.isUnixsockLocation(host):
         uristring = "PYRO:%s@%s" % (Pyro4.constants.NAMESERVER_NAME, host)
     else:
        # if not a unix socket, check for ipv6
        if ":" in host:
            host = "[%s]" % host
         uristring = "PYRO:%s@%s:%d" % (Pyro4.constants.NAMESERVER_NAME, host, port)
    
I ran the unit tests successfully.

Incidentally, I am using Pyro4 4.34 because I need to use this with Jython. This merge request is for the most recent version of Pyro. Is there a way I could create a pull request for this branch on Pyro 4.34?