### PR TITLE
Add ability to clear cached exposed metadata

### DIFF
--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -1481,6 +1481,17 @@ class Daemon(object):
             loc = self.locationStr
         return URI("PYRO:%s@%s" % (objectOrId, loc))
 
+    def resetMetadataCache(self, objectOrId, nat=True):
+        '''Reset cache of metadata when a Daemon has available methods/attributes
+        dynamically updated.  Clients will have to get a new proxy to see changes'''
+        uri = self.uriFor(objectOrId, nat)
+        # can only be cached if registered, else no-op
+        if uri.objectOrId in self.objectsById:
+            registered_object = self.objectsById[uri.object]
+            # Clear cache regardless of how it is accessed (as_lists seems to be used inconsistently)
+            util.reset_exposed_members(registered_object, Pyro4.config.REQUIRE_EXPOSE, as_lists=True)
+            util.reset_exposed_members(registered_object, Pyro4.config.REQUIRE_EXPOSE, as_lists=False)
+
     def proxyFor(self, objectOrId, nat=True):
         """
         Get a fully initialized Pyro Proxy for the given object (or object id) for this daemon.

--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -1488,7 +1488,7 @@ class Daemon(object):
         # can only be cached if registered, else no-op
         if uri.objectOrId in self.objectsById:
             registered_object = self.objectsById[uri.object]
-            # Clear cache regardless of how it is accessed (as_lists seems to be used inconsistently)
+            # Clear cache regardless of how it is accessed
             util.reset_exposed_members(registered_object, Pyro4.config.REQUIRE_EXPOSE, as_lists=True)
             util.reset_exposed_members(registered_object, Pyro4.config.REQUIRE_EXPOSE, as_lists=False)
 

--- a/src/Pyro4/util.py
+++ b/src/Pyro4/util.py
@@ -696,6 +696,10 @@ def fixIronPythonExceptionForPickle(exceptionObject, addAttributes):
 
 __exposed_member_cache = {}
 
+def reset_exposed_members(obj, only_exposed=True, as_lists=False):
+    """Delete any cached exposed members forcing recalculation on next request"""
+    cache_key = (obj, only_exposed, as_lists)
+    __exposed_member_cache.pop(cache_key, None)
 
 def get_exposed_members(obj, only_exposed=True, as_lists=False, use_cache=True):
     """

--- a/src/Pyro4/util.py
+++ b/src/Pyro4/util.py
@@ -698,6 +698,8 @@ __exposed_member_cache = {}
 
 def reset_exposed_members(obj, only_exposed=True, as_lists=False):
     """Delete any cached exposed members forcing recalculation on next request"""
+    if not inspect.isclass(obj):
+        obj = obj.__class__
     cache_key = (obj, only_exposed, as_lists)
     __exposed_member_cache.pop(cache_key, None)
 


### PR DESCRIPTION
Previous to Pyro4.46 a server could dynamically expose new methods with code like

setattr(self.class, "methodname", Pyro4.expose(method))

As long as a client created a new proxy, the new method would be available as an exposed method. Apparently the caching behavior in Pyro 4.46 changes that. Only the methods exposed when the server is initially registered are available.

I see the code in util.py on get_exposed_members() which provides for an option use_cache=True. But this is an internal method and there seems no way to change the caching behavior or pass this argument anywhere. Ideally, I could explicitly flush the cache (which is just a global in util.py) when I add methods. or just change the behavior to allow disabling the cache.

This patch adds a method resetMetadataCache on Daemon, so if the exposed methods on an object registered through a daemon are modified, a call to resetMetadataCache(objectOrID) can be used to force new proxies to discover the changes.