### PR TITLE
Added deserialize case for float('nan') from serpent

### DIFF
--- a/src/Pyro4/util.py
+++ b/src/Pyro4/util.py
@@ -369,7 +369,16 @@ class SerializerBase(object):
                 exceptiontype = getattr(sqlite3, short_classname)
                 if issubclass(exceptiontype, BaseException):
                     return SerializerBase.make_exception(exceptiontype, data)
-
+        
+        # serpent serializes float('nan') as {'__class__':'float','value':'nan'}. 
+        #  I'm not sure if this is the most elegant way to handle that edge case 
+        #  (it'd likely make more sense for this knowledge to live in 
+        #  SerpentSerializer?) - but it does the trick. ~ jackjweinstein 1/26/17
+        if classname == "float":
+            value = data.get("value", None)
+            if value == "nan":
+                return float("nan")
+            
         # try one of the serializer classes
         for serializer in _serializers.values():
             if classname == serializer.__class__.__name__:


### PR DESCRIPTION
Hi there,

First off, I just want to say, this package is bomb. I'm super impressed.

I'm using it for an application that hopefully you'll find cool, building automated test systems for the Tesla Powerwall. It's helping us gather data about the system by interfacing to NI Veristand's .NET API through IronPython, and soon we'll start running remote Python commands on some of the Linux devices that interface with Powerwalls.

I just have one problem: One of my remote machines is getting 'nan' values from the equipment it's interfacing to, and SerpentSerializer is dumping them in a way that it doesn't know how to load. I've added what feels like a crude patch to SerializerBase. Do you mind merging it, or finding a more elegant fix?

Thanks -

Jack