### PR TITLE
Add 'phase3' part for the stockquotes example

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -24,7 +24,7 @@ This avoids initial networking complexity.
     For security reasons, Pyro runs stuff on localhost by default.
     If you want to access things from different machines, you'll have to tell Pyro
     to do that explicitly.
-    At the end is a small paragraph :ref:`not-localhost` that tells you
+    At the end is a small section :ref:`not-localhost` that tells you
     how you can run the various components on different machines.
 
 .. note::
@@ -512,7 +512,7 @@ What you can see now is that you not only get the usual exception traceback, *bu
 that occurred in the remote warehouse object on the server* (the "remote traceback"). This can greatly
 help locating problems! As you can see it contains the source code lines from the warehouse code that
 is running in the server, as opposed to the normal local traceback that only shows the remote method
-call taking place inside Pyro...
+call taking place inside Pyro.
 
 
 .. index::
@@ -782,7 +782,6 @@ If you're interested to see what the name server now contains, type :command:`py
     double: tutorial; running on different machines
 
 .. _not-localhost:
-
 
 phase 3: running it on different machines
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -783,43 +783,59 @@ If you're interested to see what the name server now contains, type :command:`py
 
 .. _not-localhost:
 
-Running it on different machines
-================================
-For security reasons, Pyro runs stuff on localhost by default.
-If you want to access things from different machines, you'll have to tell Pyro to do that explicitly.
-This paragraph shows you how very briefly you can do this.
-For more details, refer to the chapters in this manual about the relevant Pyro components.
 
-*Name server*
-    to start the nameserver in such a way that it is accessible from other machines,
-    start it with an appropriate -n argument, like this: :command:`python -m Pyro4.naming -n your_hostname`
-    (or simply: :command:`pyro4-ns -n your_hostname`)
+phase 3: running it on different machines
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Before presenting the changes in phase 3, let's introduce some additional notions when working with Pyro.
 
-*Warehouse server*
-    You'll have to modify :file:`warehouse.py`. Right before the ``serveSimple`` call you have to tell it to bind the daemon on your hostname
-    instead of localhost. One way to do this is by setting the ``HOST`` config item::
+It's important for you to understand that, for security reasons, Pyro runs stuff on localhost by default. 
+If you want to access things from different machines, you'll have to tell Pyro to do that explicitly. 
+Here we show you how you can do this:
 
-        Pyro4.config.HOST = "your_hostname_here"
-        Pyro4.Daemon.serveSimple(...)
+Let's assume that you want to start the *name server* in such a way that it is accessible from other machines. 
+To do that, type in the console one of two options (with an appropriate -n argument):
 
-    Optional: you can choose to leave the code alone, and instead set the ``PYRO_HOST`` environment variable
-    before starting the warehouse server.
-    Another choice is to pass the required host (and perhaps even port) arguments to ``serveSimple``::
+    $ python -m Pyro4.naming -n your_hostname    # i.e. your_hostname = "192.168.1.99"
 
-        Pyro4.Daemon.serveSimple(
-                {
-                    Warehouse: "example.warehouse"
-                },
-                host = 'your_hostname_here',
-                ns = True)
+or simply:
 
-*Stock market server*
-    This example already creates a daemon object instead of using the :py:meth:`serveSimple` call.
-    You'll have to modify the stockmarket source file because that is the one creating a daemon.
-    But you'll only have to add the proper ``host`` argument to the construction of the Daemon,
-    to set it to your machine name instead of the default of localhost.
-    Of course, you could also change the ``HOST`` config item (either in the code itself,
-    or by setting the ``PYRO_HOST`` environment variable before launching).
+    $ pyro4-ns -n your_hostname
+
+If you want to implement this concept on the *warehouse server*, you'll have to modify :file:`warehouse.py`. 
+Then, right before the ``serveSimple`` call, you have to tell it to bind the daemon on your hostname instead 
+of localhost. One way to do this is by setting the ``HOST`` config item::
+
+    Pyro4.config.HOST = "your_hostname_here"
+    Pyro4.Daemon.serveSimple(...)
+
+Optionally, you can choose to leave the code alone, and instead set the ``PYRO_HOST`` environment variable 
+before starting the warehouse server. Another choice is to pass the required host (and perhaps even port) 
+arguments to ``serveSimple``::
+
+    Pyro4.Daemon.serveSimple(
+            {
+                Warehouse: "example.warehouse"
+            },
+            host = 'your_hostname_here',
+            ns = True)
+
+Remember that if you want more details, refer to the chapters in this manual about the relevant Pyro components.
+
+Now, back on the new version of the *stock market server*, notice that this example already creates a daemon 
+object instead of using the :py:meth:`serveSimple` call. You'll have to modify :file:`stockmarket.py` because 
+that is the one creating a daemon. But you'll only have to add the proper ``host``and ``port`` arguments to 
+the construction of the Daemon, to set it to your machine name instead of the default of localhost. Let's see 
+the few minor changes that are required in the code:
+
+    ...
+    HOST_IP = "192.168.1.99"
+    HOST_PORT = 9092
+    ...
+    with Pyro4.Daemon(host=HOST_IP, port=HOST_PORT) as daemon:
+    ...
+
+Of course, you could also change the ``HOST`` config item (either in the code itself, or by setting 
+the ``PYRO_HOST`` environment variable before launching).
 
 Other means of creating connections
 ===================================

--- a/examples/stockquotes/Readme.txt
+++ b/examples/stockquotes/Readme.txt
@@ -20,7 +20,7 @@ decide themselves when a new quote is available, can be found in the
 example 'stockquotes-old'.  It uses callbacks instead of generators.
 
 
-The tutorial here consists of 2 phases:
+The tutorial here consists of 3 phases:
 
 phase 1:
     Simple prototype code where everything is running in a single process.
@@ -44,3 +44,20 @@ phase 2:
     Support for remote iterators/generators is available since Pyro 4.49.
     In the viewer we didn't hardcode the stock market names but instead
     we ask the name server for all available stock markets.
+
+phase 3:
+    Similar to phase2, but now we make two small changes:
+    a) we use the Pyro name server in such a way that it is accessible 
+    from other machines, and b) we run the stock market server in a way 
+    that the host is not "localhost" by default and can be accessed by 
+    different machines. To do this, create the daemon with the 
+    arguments 'host' and 'port' set (i.e. host=HOST_IP, port=HOST_PORT). 
+    Again, you have to start both component by itself (in separate 
+    console windows for instance):
+    - start a Pyro name server like this:
+    (python -m Pyro4.naming -n 192.168.1.99 -p 9091) or
+    (pyro4-ns -n 192.168.1.99 -p 9091)
+    - start the stockmarket.py (set HOST_IP and HOST_PORT accordingly. 
+    Also, make sure HOST_PORT is already open).
+    - start the viewer.py in different remote machines to see the stream 
+    of quotes coming in on each window.

--- a/examples/stockquotes/phase3/stockmarket.py
+++ b/examples/stockquotes/phase3/stockmarket.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+import random
+import time
+import Pyro4
+
+HOST_IP = "127.0.0.1"    # Set accordingly (i.e. "192.168.1.99")
+HOST_PORT = 9092         # Set accordingly (i.e. 9876)
+
+
+@Pyro4.expose
+class StockMarket(object):
+    def __init__(self, marketname, symbols):
+        self._name = marketname
+        self._symbols = symbols
+
+    def quotes(self):
+        while True:
+            symbol = random.choice(self.symbols)
+            yield symbol, round(random.uniform(5, 150), 2)
+            time.sleep(random.random()/2.0)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def symbols(self):
+        return self._symbols
+
+
+if __name__ == "__main__":
+    nasdaq = StockMarket("NASDAQ", ["AAPL", "CSCO", "MSFT", "GOOG"])
+    newyork = StockMarket("NYSE", ["IBM", "HPQ", "BP"])
+    # Add the proper "host" and "port" arguments for the construction 
+    # of the Daemon so it can be accessed remotely 
+    with Pyro4.Daemon(host=HOST_IP, port=HOST_PORT) as daemon:
+        nasdaq_uri = daemon.register(nasdaq)
+        newyork_uri = daemon.register(newyork)
+        with Pyro4.locateNS() as ns:
+            ns.register("example.stockmarket.nasdaq", nasdaq_uri)
+            ns.register("example.stockmarket.newyork", newyork_uri)
+        print("Stockmarkets available.")
+        daemon.requestLoop()

--- a/examples/stockquotes/phase3/viewer.py
+++ b/examples/stockquotes/phase3/viewer.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+import Pyro4
+
+
+class Viewer(object):
+    def __init__(self):
+        self.markets = set()
+        self.symbols = set()
+
+    def start(self):
+        print("Shown quotes:", self.symbols)
+        quote_sources = {
+            market.name: market.quotes() for market in self.markets
+        }
+        while True:
+            for market, quote_source in quote_sources.items():
+                quote = next(quote_source)  # get a new stock quote from the source
+                symbol, value = quote
+                if symbol in self.symbols:
+                    print("{0}.{1}: {2}".format(market, symbol, value))
+
+
+def find_stockmarkets():
+    # You can hardcode the stockmarket names for nasdaq and newyork, but it
+    # is more flexible if we just look for every available stockmarket.
+    markets = []
+    with Pyro4.locateNS() as ns:
+        for market, market_uri in ns.list(prefix="example.stockmarket.").items():
+            print("found market", market)
+            markets.append(Pyro4.Proxy(market_uri))
+    if not markets:
+        raise ValueError("no markets found! (have you started the stock markets first?)")
+    return markets
+
+
+def main():
+    viewer = Viewer()
+    viewer.markets = find_stockmarkets()
+    viewer.symbols = {"IBM", "AAPL", "MSFT"}
+    viewer.start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a "new phase" to the stockquotes example, which allow us to work with Pyro in such a way remote components are accessible explicitly. This also helps to complement the section "Running it on different machines" section of the tutorial.