### PR TITLE
Issue when nameserver is bound to 0.0.0.0 and accessed by http gateway

### DIFF
--- a/src/Pyro4/utils/httpgateway.py
+++ b/src/Pyro4/utils/httpgateway.py
@@ -168,7 +168,7 @@ def return_homepage(environ, start_response):
         for name, uri in zip(names, nsbatch()):
             attributes = "-"
             try:
-                if name == nameserver._pyroUri.object:
+                if name == nameserver._pyroUri.object and uri.host == '0.0.0.0':
                     uri = nameserver._pyroUri
                 with core.Proxy(uri) as proxy:
                     proxy._pyroHmacKey = pyro_app.hmac_key

--- a/src/Pyro4/utils/httpgateway.py
+++ b/src/Pyro4/utils/httpgateway.py
@@ -168,6 +168,8 @@ def return_homepage(environ, start_response):
         for name, uri in zip(names, nsbatch()):
             attributes = "-"
             try:
+                if name == nameserver._pyroUri.object:
+                    uri = nameserver._pyroUri
                 with core.Proxy(uri) as proxy:
                     proxy._pyroHmacKey = pyro_app.hmac_key
                     proxy._pyroBind()

--- a/tests/PyroTests/test_httpgateway.py
+++ b/tests/PyroTests/test_httpgateway.py
@@ -18,7 +18,7 @@ from Pyro4.configuration import config
 # a bit of hackery to avoid having to launch a live name server
 def get_nameserver_dummy(hmac=None):
     class NameServerDummyProxy(NameServer):
-		_pyroUri = "PYRO:dummy12345@localhost:59999"
+        _pyroUri = "PYRO:dummy12345@localhost:59999"
         def __init__(self):
             super(NameServerDummyProxy, self).__init__()
             self.register("http.ObjectName", "PYRO:dummy12345@localhost:59999")

--- a/tests/PyroTests/test_httpgateway.py
+++ b/tests/PyroTests/test_httpgateway.py
@@ -18,6 +18,7 @@ from Pyro4.configuration import config
 # a bit of hackery to avoid having to launch a live name server
 def get_nameserver_dummy(hmac=None):
     class NameServerDummyProxy(NameServer):
+		_pyroUri = "PYRO:dummy12345@localhost:59999"
         def __init__(self):
             super(NameServerDummyProxy, self).__init__()
             self.register("http.ObjectName", "PYRO:dummy12345@localhost:59999")

--- a/tests/PyroTests/test_httpgateway.py
+++ b/tests/PyroTests/test_httpgateway.py
@@ -18,9 +18,7 @@ from Pyro4.configuration import config
 # a bit of hackery to avoid having to launch a live name server
 def get_nameserver_dummy(hmac=None):
     class NameServerDummyProxy(NameServer):
-        class Proxy(object):
-            object = "PYRO:dummy12345@localhost:59999"
-        _pyroUri = Proxy
+        _pyroUri = Pyro4.core.URI("PYRO:dummy12345@localhost:59999")
         def __init__(self):
             super(NameServerDummyProxy, self).__init__()
             self.register("http.ObjectName", "PYRO:dummy12345@localhost:59999")

--- a/tests/PyroTests/test_httpgateway.py
+++ b/tests/PyroTests/test_httpgateway.py
@@ -18,7 +18,9 @@ from Pyro4.configuration import config
 # a bit of hackery to avoid having to launch a live name server
 def get_nameserver_dummy(hmac=None):
     class NameServerDummyProxy(NameServer):
-        _pyroUri = "PYRO:dummy12345@localhost:59999"
+        class Proxy(object):
+            object = "PYRO:dummy12345@localhost:59999"
+        _pyroUri = Proxy
         def __init__(self):
             super(NameServerDummyProxy, self).__init__()
             self.register("http.ObjectName", "PYRO:dummy12345@localhost:59999")


### PR DESCRIPTION
If we are looking up the nameserver, use the uri that we are currently using as the connection. The nameserver itself my have regiested it self with host ip may be 0.0.0.0 which we cannot bind to. Thus we are changing the nameserver address to one to which we can connect to.