### PR TITLE
Update documentation for SOCK_REUSE

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -96,7 +96,7 @@ BROADCAST_ADDRS           str     <broadcast>, 0.0.0.0    List of comma separate
 ONEWAY_THREADED           bool    True                    Enable to make oneway calls be processed in their own separate thread
 POLLTIMEOUT               float   2.0                     For the multiplexing server only: the timeout of the select or poll calls
 SERVERTYPE                str     thread                  Select the Pyro server type. thread=thread pool based, multiplex=select/poll/kqueue based
-SOCK_REUSE                bool    False                   Should SO_REUSEADDR be used on sockets that Pyro creates.
+SOCK_REUSE                bool    True                    Should SO_REUSEADDR be used on sockets that Pyro creates.
 PREFER_IP_VERSION         int     4                       The IP address type that is preferred (4=ipv4, 6=ipv6, 0=let OS decide).
 THREADPOOL_SIZE           int     40                      For the thread pool server: maximum number of threads running
 THREADPOOL_SIZE_MIN       int     4                       For the thread pool server: minimum number of threads running


### PR DESCRIPTION
Super tiny change. You forgot to update the docs with the new default value for SOCK_REUSE.