### PR TITLE
Problem with config.NATPORT

### DIFF
--- a/examples/eventloop/Readme.txt
+++ b/examples/eventloop/Readme.txt
@@ -4,7 +4,7 @@ and that it needs to detect when 'events' happen on the appropriate
 Pyro objects. This particular example uses select to wait for the
 set of objects (sockets, really) and calls the correct event handler.
 You can add your own application's sockets easily this way.
-See the 'sever_threads.py' how this is done.
+See the 'server_threads.py' how this is done.
 
 Since Pyro 4.44 it is possible to easily merge/combine the event loops
 of different daemons. This way you don't have to write your own event

--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -1113,8 +1113,8 @@ class Daemon(object):
                 host = config.HOST
             if nathost is None:
                 nathost = config.NATHOST
-            if natport is None:
-                natport = config.NATPORT or None
+            if natport is None and nathost is not None:
+                natport = config.NATPORT
             if nathost and unixsocket:
                 raise ValueError("cannot use nathost together with unixsocket")
             if (nathost is None) ^ (natport is None):


### PR DESCRIPTION
I ran into a problem with using NATPORT=0, `config.NATPORT or None` turning into `None` when the value is 0, and subsequently failing on line 1119

I also had to add the `and nathost is not None` to leave `natport` set to `None` when not using `nathost` at all, as that was breaking things like `pyro4-ns --host=172.31.3.54`

I think a slightly different/better fix may be to set the default for `config.NATPORT` to `None` as well.