### PR TITLE
allow cythonized class's methods to be exposed

### DIFF
--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -1004,7 +1004,7 @@ def expose(method_or_class):
             if util.is_private_attribute(name):
                 continue
             thing = getattr(clazz, name)
-            if inspect.isfunction(thing):
+            if inspect.isfunction(thing) or inspect.ismethoddescriptor(thing):
                 thing._pyroExposed = True
             elif inspect.ismethod(thing):
                 thing.__func__._pyroExposed = True


### PR DESCRIPTION
When a class is cythonized, its methods become `cython_function_or_method` instead of `function`.
Then both `inspect.isfunction` and `inspect.ismethod` returns `False` on `cython_function_or_method`, so that `@expose` does not expose those methods.

To fix the problem I follow https://github.com/irmen/Pyro4/pull/208 to use `inspect.ismethoddescriptor` as 
It seems to return `True` on `cython_function_or_method` (https://gist.github.com/msakai/c1191c8fedea3396056de1a04841213f).

I'm using:
* Python 3.6.3
* Pyro4 4.78
* Cython 0.29.14
