### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/source/tipstricks.rst
+++ b/docs/source/tipstricks.rst
@@ -119,7 +119,7 @@ A little example to enable logging by setting the required environment variables
     $ export PYRO_LOGLEVEL=DEBUG
     $ python my_pyro_program.py
 
-Another way is by modifiying ``os.environ`` from within your code itself, *before* any import of Pyro4 is done::
+Another way is by modifying ``os.environ`` from within your code itself, *before* any import of Pyro4 is done::
 
     import os
     os.environ["PYRO_LOGFILE"] = "pyro.log"

--- a/examples/itunes/itunescontroller.py
+++ b/examples/itunes/itunescontroller.py
@@ -35,7 +35,7 @@ class ITunes(object):
         subprocess.call(["osascript", "-e", "tell application \"iTunes\" to previous track"])
 
     def playlist(self, listname):
-        # start playling a defined play list
+        # start playing a defined play list
         subprocess.call(["osascript", "-e", "tell application \"iTunes\" to play playlist \"{0}\"".format(listname)])
 
     def currentsong(self):

--- a/examples/messagebus/messagebus/__init__.py
+++ b/examples/messagebus/messagebus/__init__.py
@@ -1,6 +1,6 @@
 """
 Pyro MessageBus:  a simple pub/sub message bus.
-Provides a way of cummunicating where the sender and receivers are fully decoupled.
+Provides a way of communicating where the sender and receivers are fully decoupled.
 
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """

--- a/examples/messagebus/messagebus/messagebus.py
+++ b/examples/messagebus/messagebus/messagebus.py
@@ -1,6 +1,6 @@
 """
 Pyro MessageBus:  a simple pub/sub message bus.
-Provides a way of cummunicating where the sender and receivers are fully decoupled.
+Provides a way of communicating where the sender and receivers are fully decoupled.
 
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """

--- a/examples/messagebus/messagebus/server.py
+++ b/examples/messagebus/messagebus/server.py
@@ -1,6 +1,6 @@
 """
 Pyro MessageBus:  a simple pub/sub message bus.
-Provides a way of cummunicating where the sender and receivers are fully decoupled.
+Provides a way of communicating where the sender and receivers are fully decoupled.
 
 Pyro - Python Remote Objects.  Copyright by Irmen de Jong (irmen@razorvine.net).
 """

--- a/src/Pyro4/futures.py
+++ b/src/Pyro4/futures.py
@@ -78,7 +78,7 @@ class Future(object):
     def delay(self, seconds):
         """
         Delay the evaluation of the future for the given number of seconds.
-        Return True if succesful otherwise False if the future has already been evaluated.
+        Return True if successful otherwise False if the future has already been evaluated.
         """
         if self.completed:
             return False
@@ -88,7 +88,7 @@ class Future(object):
     def cancel(self):
         """
         Cancels the execution of the future altogether.
-        If the execution hasn't been started yet, the cancellation is succesful and returns True.
+        If the execution hasn't been started yet, the cancellation is successful and returns True.
         Otherwise, it failed and returns False.
         """
         if self.completed:


### PR DESCRIPTION
There are small typos in:
- docs/source/tipstricks.rst
- examples/itunes/itunescontroller.py
- examples/messagebus/messagebus/__init__.py
- examples/messagebus/messagebus/messagebus.py
- examples/messagebus/messagebus/server.py
- src/Pyro4/futures.py

Fixes:
- Should read `communicating` rather than `cummunicating`.
- Should read `successful` rather than `succesful`.
- Should read `playing` rather than `playling`.
- Should read `modifying` rather than `modifiying`.

Closes #235