### PR TITLE
also raise on exposed Python 3.10 cmethod/smethod

### DIFF
--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -987,7 +987,7 @@ def expose(method_or_class):
         func._pyroExposed = True
         return method_or_class
     attrname = getattr(method_or_class, "__name__", None)
-    if not attrname:
+    if not attrname or attrname in ['cmethod', 'smethod']:
         # we could be dealing with a descriptor (classmethod/staticmethod), this means the order of the decorators is wrong
         if inspect.ismethoddescriptor(method_or_class):
             attrname = method_or_class.__get__(None, dict).__name__


### PR DESCRIPTION
`tests/PyroTests/test_util.py::TestMetaAndExpose::testClassmethodExposeWrongOrderFail` fails on Python 3.10, because there was a change in the API:

```
abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.80> cat mytest.py
def mydeco(method_or_class):
   attrname = getattr(method_or_class, "__name__", None)
   print(attrname)
   return method_or_class

class TestClass:
  @mydeco
  @classmethod
  def cmethod(cls):
     pass

  @mydeco
  @staticmethod
  def smethod(cls):
     pass


abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.80> python3.8 mytest.py 
None
None
abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.80> python3.10 mytest.py 
cmethod
smethod
```