### PR TITLE
also raise on exposed Python 3.10 cmethod/smethod

### DIFF
--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -987,7 +987,7 @@ def expose(method_or_class):
         func._pyroExposed = True
         return method_or_class
     attrname = getattr(method_or_class, "__name__", None)
-    if not attrname:
+    if not attrname or isinstance(method_or_class, (classmethod, staticmethod)):
         # we could be dealing with a descriptor (classmethod/staticmethod), this means the order of the decorators is wrong
         if inspect.ismethoddescriptor(method_or_class):
             attrname = method_or_class.__get__(None, dict).__name__


### PR DESCRIPTION
New version of #237.

`test_util.py::TestMetaAndExpose::testClassmethodExposeWrongOrderFail` fails on Python 3.10, because there was a change in the API:

```python
def mydeco(method_or_class):
   attrname = getattr(method_or_class, "__name__", None)
   print(attrname, isinstance(method_or_class, (staticmethod, classmethod)))
   return method_or_class

class TestClass:
  @mydeco
  @classmethod
  def cmethod_F(cls):
     pass

  @mydeco
  @staticmethod
  def smethod_F(cls):
     pass

  @classmethod
  @mydeco
  def cmethod_OK(cls):
     pass

  @staticmethod
  @mydeco
  def smethod_OK(cls):
     pass
```

```python
abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.81> python2 mytest.py
(None, True)
(None, True)
('cmethod_OK', False)
('smethod_OK', False)
abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.81> python3.8 mytest.py 
None True
None True
cmethod_OK False
smethod_OK False
abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.81> python3.10 mytest.py 
cmethod_F True
smethod_F True
cmethod_OK False
smethod_OK False
abuild@skylab:~/rpmbuild/BUILD/Pyro4-4.81>
```