### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ The documentation can be found here: http://pyro4.readthedocs.io
         author_email="irmen@razorvine.net",
         keywords=["distributed objects", "RPC", "remote method call", "IPC"],
         url="http://pyro4.readthedocs.io",
+        project_urls={
+            "Source": "https://github.com/irmen/Pyro4",
+        },
         package_dir={'': 'src'},
         packages=['Pyro4', 'Pyro4.socketserver', 'Pyro4.test', 'Pyro4.utils'],
         scripts=[],


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)