### PR TITLE
Replace deprecated threading aliases

### DIFF
--- a/examples/chatbox/client.py
+++ b/examples/chatbox/client.py
@@ -57,7 +57,7 @@ class DaemonThread(threading.Thread):
     def __init__(self, chatter):
         threading.Thread.__init__(self)
         self.chatter = chatter
-        self.setDaemon(True)
+        self.daemon = True
 
     def run(self):
         with Pyro4.core.Daemon() as daemon:

--- a/examples/deadlock/client.py
+++ b/examples/deadlock/client.py
@@ -32,7 +32,7 @@ def main():
 
     # create a thread that handles callback requests
     thread = threading.Thread(target=PyroLoop, args=(daemon,))
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
 
     print("This bounce example will deadlock!")

--- a/examples/filetransfer/client.py
+++ b/examples/filetransfer/client.py
@@ -16,7 +16,7 @@ def regular_pyro(uri):
     num_blobs = 10
     total_size = 0
     start = time.time()
-    name = threading.currentThread().name
+    name = threading.current_thread().name
     with Pyro4.core.Proxy(uri) as p:
         for _ in range(num_blobs):
             print("thread {0} getting a blob using regular Pyro call...".format(name))
@@ -33,7 +33,7 @@ def via_iterator(uri):
     num_blobs = 10
     total_size = 0
     start = time.time()
-    name = threading.currentThread().name
+    name = threading.current_thread().name
     with Pyro4.core.Proxy(uri) as p:
         for _ in range(num_blobs):
             print("thread {0} getting a blob using remote iterators...".format(name))
@@ -46,7 +46,7 @@ def via_iterator(uri):
 
 
 def via_annotation_stream(uri):
-    name = threading.currentThread().name
+    name = threading.current_thread().name
     start = time.time()
     total_size = 0
     print("thread {0} downloading via annotation stream...".format(name))
@@ -67,7 +67,7 @@ def raw_socket(uri):
     blobsize = 40*1024*1024
     num_blobs = 10
     total_size = 0
-    name = threading.currentThread().name
+    name = threading.current_thread().name
     with Pyro4.core.Proxy(uri) as p:
         print("thread {0} preparing {1} blobs of size {2} Mb".format(name, num_blobs, blobsize/1024.0/1024.0))
         blobs = {}

--- a/examples/gui_eventloop/gui_threads.py
+++ b/examples/gui_eventloop/gui_threads.py
@@ -158,7 +158,7 @@ def main():
 
     # create a pyro daemon with object, running in its own worker thread
     pyro_thread = PyroDaemon(gui)
-    pyro_thread.setDaemon(True)
+    pyro_thread.daemon = True
     pyro_thread.start()
     pyro_thread.started.wait()
 

--- a/examples/proxysharing/client.py
+++ b/examples/proxysharing/client.py
@@ -1,22 +1,16 @@
 from __future__ import print_function
-import sys
 import time
 import threading
 import Pyro4.naming
 import Pyro4.core
 
 
-if sys.version_info < (3, 0):
-    current_thread = threading.currentThread
-else:
-    current_thread = threading.current_thread
-
 stop = False
 
 
 def myThread(nsproxy, proxy):
     global stop
-    name = current_thread().getName()
+    name = threading.current_thread().name
     try:
         while not stop:
             result = nsproxy.list(prefix="example.")
@@ -32,8 +26,8 @@ proxy = Pyro4.core.Proxy("PYRONAME:example.proxysharing")
 threads = []
 for i in range(5):
     thread = threading.Thread(target=myThread, args=(nsproxy, proxy))
-    # thread.setDaemon(True)
-    thread.setDaemon(False)
+    # thread.daemon = True
+    thread.daemon = False
     threads.append(thread)
     thread.start()
 
@@ -61,7 +55,7 @@ proxy.reset_work()
 threads = []
 for i in range(10):
     thread = threading.Thread(target=myThread2, args=[proxy])
-    thread.setDaemon(False)
+    thread.daemon = False
     threads.append(thread)
     thread.start()
 
@@ -86,7 +80,7 @@ threads = []
 for i in range(10):
     proxy = Pyro4.core.Proxy(proxy._pyroUri)  # create a new proxy
     thread = threading.Thread(target=myThread2, args=[proxy])
-    thread.setDaemon(False)
+    thread.daemon = False
     threads.append(thread)
     thread.start()
 

--- a/examples/robots/gameserver.py
+++ b/examples/robots/gameserver.py
@@ -243,7 +243,7 @@ class PyroDaemonThread(threading.Thread):
         self.pyroserver = remote.GameServer(engine)
         self.pyrodaemon = Pyro4.Daemon()
         self.ns = Pyro4.locateNS()
-        self.setDaemon(True)
+        self.daemon = True
 
     def run(self):
         with self.pyrodaemon:

--- a/examples/servertypes/client.py
+++ b/examples/servertypes/client.py
@@ -1,14 +1,8 @@
 from __future__ import print_function
-import sys
 import time
 import threading
 import Pyro4
 
-
-if sys.version_info < (3, 0):
-    current_thread = threading.currentThread
-else:
-    current_thread = threading.current_thread
 
 serv = Pyro4.core.Proxy("PYRONAME:example.servertypes")
 
@@ -68,14 +62,14 @@ def func(uri):
     # This will run in a thread. Create a proxy just for this thread:
     with Pyro4.core.Proxy(uri) as p:
         processed = p.delay()
-        print("[ thread %s called delay, processed by: %s ]  " % (current_thread().getName(), processed))
+        print("[ thread %s called delay, processed by: %s ]  " % (threading.current_thread().name, processed))
 
 
 serv._pyroBind()  # simplify the uri
 threads = []
 for i in range(5):
     t = threading.Thread(target=func, args=[serv._pyroUri])
-    t.setDaemon(True)
+    t.daemon = True
     threads.append(t)
     t.start()
 print("Waiting for threads to finish:")

--- a/examples/servertypes/server.py
+++ b/examples/servertypes/server.py
@@ -7,9 +7,6 @@ import Pyro4
 
 if sys.version_info < (3, 0):
     input = raw_input
-    current_thread = threading.currentThread
-else:
-    current_thread = threading.current_thread
 
 
 @Pyro4.expose
@@ -28,7 +25,7 @@ class Server(object):
         return Pyro4.config.asDict()
 
     def delay(self):
-        threadname = current_thread().getName()
+        threadname = threading.current_thread().name
         print("delay called in thread %s" % threadname)
         time.sleep(1)
         self.callcount += 1
@@ -36,7 +33,7 @@ class Server(object):
 
     @Pyro4.oneway
     def onewaydelay(self):
-        threadname = current_thread().getName()
+        threadname = current_thread().name
         print("onewaydelay called in thread %s" % threadname)
         time.sleep(1)
         self.callcount += 1

--- a/examples/servertypes/server.py
+++ b/examples/servertypes/server.py
@@ -33,7 +33,7 @@ class Server(object):
 
     @Pyro4.oneway
     def onewaydelay(self):
-        threadname = current_thread().name
+        threadname = threading.current_thread().name
         print("onewaydelay called in thread %s" % threadname)
         time.sleep(1)
         self.callcount += 1

--- a/examples/stockquotes-old/phase2/stockmarket.py
+++ b/examples/stockquotes-old/phase2/stockmarket.py
@@ -35,7 +35,7 @@ class StockMarket(object):
                 self.generate()
 
         thread = threading.Thread(target=generate_symbols)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
 

--- a/examples/stockquotes-old/phase3/stockmarket.py
+++ b/examples/stockquotes-old/phase3/stockmarket.py
@@ -39,7 +39,7 @@ class StockMarket(object):
                 self.generate()
 
         thread = threading.Thread(target=generate_symbols)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
 

--- a/src/Pyro4/core.py
+++ b/src/Pyro4/core.py
@@ -898,7 +898,7 @@ class _AsyncRemoteMethod(object):
     def __call__(self, *args, **kwargs):
         result = futures.FutureResult()
         thread = threading.Thread(target=self.__asynccall, args=(result, args, kwargs))
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
         return result
 
@@ -1231,7 +1231,7 @@ class Daemon(object):
         log.info("daemon %s entering requestloop", self.locationStr)
         try:
             self.__loopstopped.clear()
-            condition = lambda: not self.__mustshutdown.isSet() and loopCondition()
+            condition = lambda: not self.__mustshutdown.is_set() and loopCondition()
             self.transportServer.loop(loopCondition=condition)
         finally:
             self.__loopstopped.set()

--- a/src/Pyro4/futures.py
+++ b/src/Pyro4/futures.py
@@ -48,7 +48,7 @@ class Future(object):
         del self.chain  # make it impossible to add new calls to the chain once we started executing it
         result = FutureResult()  # notice that the call chain doesn't sit on the result object
         thread = threading.Thread(target=self.__asynccall, args=(result, chain, args, kwargs))
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
         return result
 
@@ -138,13 +138,13 @@ class FutureResult(object):
         result = self.__ready.wait(timeout)
         if result is None:
             # older pythons return None from wait()
-            return self.__ready.isSet()
+            return self.__ready.is_set()
         return result
 
     @property
     def ready(self):
         """Boolean that contains the readiness of the asynchronous result"""
-        return self.__ready.isSet()
+        return self.__ready.is_set()
 
     def get_value(self):
         self.__ready.wait()
@@ -182,7 +182,7 @@ class FutureResult(object):
         Returns self so you can easily chain then() calls.
         """
         with self.valueLock:
-            if self.__ready.isSet():
+            if self.__ready.is_set():
                 # value is already known, we need to process it immediately (can't use the call chain anymore)
                 call = functools.partial(call, self.__value)
                 self.__value = call(*args, **kwargs)

--- a/src/Pyro4/naming.py
+++ b/src/Pyro4/naming.py
@@ -418,7 +418,7 @@ class BroadcastServer(object):
     def runInThread(self):
         """Run the broadcast server loop in its own thread."""
         thread = threading.Thread(target=self.__requestLoop)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
         log.debug("broadcast server loop running in own thread")
         return thread

--- a/src/Pyro4/test/echoserver.py
+++ b/src/Pyro4/test/echoserver.py
@@ -123,7 +123,7 @@ class EchoServer(object):
 class NameServer(threading.Thread):
     def __init__(self, hostname, hmac=None):
         super(NameServer, self).__init__()
-        self.setDaemon(1)
+        self.daemon = 1
         self.hostname = hostname
         self.hmac = hmac
         self.started = threading.Event()

--- a/tests/PyroTests/test_echoserver.py
+++ b/tests/PyroTests/test_echoserver.py
@@ -15,7 +15,7 @@ from Pyro4.configuration import config
 class EchoServerThread(Thread):
     def __init__(self):
         super(EchoServerThread, self).__init__()
-        self.setDaemon(True)
+        self.daemon = True
         self.started = Event()
         self.echodaemon = self.echoserver = self.uri = None
 

--- a/tests/PyroTests/test_naming.py
+++ b/tests/PyroTests/test_naming.py
@@ -18,7 +18,7 @@ from Pyro4.configuration import config
 class NSLoopThread(threading.Thread):
     def __init__(self, nameserver):
         super(NSLoopThread, self).__init__()
-        self.setDaemon(True)
+        self.daemon = True
         self.nameserver = nameserver
         self.running = threading.Event()
         self.running.clear()

--- a/tests/PyroTests/test_server.py
+++ b/tests/PyroTests/test_server.py
@@ -123,7 +123,7 @@ class NotEverythingExposedClass(object):
 class DaemonLoopThread(threading.Thread):
     def __init__(self, pyrodaemon):
         super(DaemonLoopThread, self).__init__()
-        self.setDaemon(True)
+        self.daemon = True
         self.pyrodaemon = pyrodaemon
         self.running = threading.Event()
         self.running.clear()
@@ -693,7 +693,7 @@ class ServerTestsOnce(unittest.TestCase):
                 threading.Thread.__init__(self)
                 self.proxy = proxy
                 self.event = event
-                self.setDaemon(True)
+                self.daemon = True
                 self.new_connections.reset()
 
             def run(self):
@@ -1038,7 +1038,7 @@ class ServerTestsThreadNoTimeout(unittest.TestCase):
                 self.proxy = proxy
                 self.terminate = False
                 self.error = True
-                self.setDaemon(True)
+                self.daemon = True
 
             def run(self):
                 try:
@@ -1081,7 +1081,7 @@ class ServerTestsThreadNoTimeout(unittest.TestCase):
         class ClientThread(threading.Thread):
             def __init__(self, uri, name):
                 super(ClientThread, self).__init__()
-                self.setDaemon(True)
+                self.daemon = True
                 self.proxy = Pyro4.core.Proxy(uri)
                 self.name = name
                 self.error = True

--- a/tests/PyroTests/test_socket.py
+++ b/tests/PyroTests/test_socket.py
@@ -323,7 +323,7 @@ class TestSocketutil(unittest.TestCase):
         ss = SU.createSocket(bind=("localhost", 0))
         SIZES = [1000, 10000, 32000, 32768, 32780, 41950, 41952, 42000, 65000, 65535, 65600, 80000, 999999]
         serverthread = ReceiveThread(ss, SIZES)
-        serverthread.setDaemon(True)
+        serverthread.daemon = True
         serverthread.start()
         port = ss.getsockname()[1]
         cs = SU.createSocket(connect=("localhost", port), timeout=2)


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

Similarly for: `getName()` and `setDaemon()`.

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174
